### PR TITLE
Implement regional plant catalog and update plant model

### DIFF
--- a/Greyspace/GardenStore.swift
+++ b/Greyspace/GardenStore.swift
@@ -27,11 +27,36 @@ final class GardenStoreSwiftData: GardenStorage {
         }
     }
 
-    init(container: ModelContainer = {
-        let schema = Schema([GardenStateModel.self])
-        return try! ModelContainer(for: schema)
-    }()) {
+    init(container: ModelContainer) {
         self.container = container
+    }
+
+    static func makeDefaultContainer() throws -> ModelContainer {
+        let schema = Schema([GardenStateModel.self])
+        let url = try storeURL()
+        let configuration = ModelConfiguration(url: url)
+        return try ModelContainer(for: schema, configurations: configuration)
+    }
+
+    static func make() -> GardenStoreSwiftData? {
+        do {
+            return try GardenStoreSwiftData(container: makeDefaultContainer())
+        } catch {
+            #if DEBUG
+            print("Failed to create GardenStoreSwiftData container:", error)
+            #endif
+            return nil
+        }
+    }
+
+    private static func storeURL() throws -> URL {
+        let base = try FileManager.default.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return base.appendingPathComponent("GrowWithMe.store")
     }
 
     func loadState() -> GardenState {
@@ -156,7 +181,9 @@ final class GardenStore: ObservableObject {
     static func makeDefault() -> GardenStore {
         #if canImport(SwiftData)
         if #available(iOS 17, *) {
-            return GardenStore(storage: GardenStoreSwiftData())
+            if let store = GardenStoreSwiftData.make() {
+                return GardenStore(storage: store)
+            }
         }
         #endif
         return GardenStore(storage: GardenStoreUserDefaults())

--- a/Greyspace/GardenStore.swift
+++ b/Greyspace/GardenStore.swift
@@ -89,13 +89,13 @@ final class GardenStoreUserDefaults: GardenStorage {
 // MARK: - GardenStore
 
 @MainActor
-public final class GardenStore: ObservableObject {
-    @Published public private(set) var state: GardenState
+final class GardenStore: ObservableObject {
+    @Published private(set) var state: GardenState
 
     private let storage: GardenStorage
     private let calendar: Calendar
 
-    public init(
+    init(
         storage: GardenStorage,
         initialState: GardenState? = nil,
         calendar: Calendar = .current
@@ -105,7 +105,7 @@ public final class GardenStore: ObservableObject {
         self.state = initialState ?? storage.loadState()
     }
 
-    public static func makeDefault() -> GardenStore {
+    static func makeDefault() -> GardenStore {
         #if canImport(SwiftData)
         if #available(iOS 17, *) {
             return GardenStore(storage: GardenStoreSwiftData())
@@ -116,30 +116,30 @@ public final class GardenStore: ObservableObject {
 
     // MARK: - Onboarding
 
-    public func markOnboardingCompleted() {
+    func markOnboardingCompleted() {
         state.hasCompletedOnboarding = true
         persist()
     }
 
-    public func resetOnboarding() {
+    func resetOnboarding() {
         state.hasCompletedOnboarding = false
         persist()
     }
 
     // MARK: - Plant Lifecycle
 
-    public func startRun(with plant: PlantChoice) {
+    func startRun(with plant: PlantChoice) {
         state.activeRun = PlantRun(plant: plant, startDate: Date())
         persist()
     }
 
-    public func abandonRun() {
+    func abandonRun() {
         state.activeRun = nil
         persist()
     }
 
     @discardableResult
-    public func recordDailyProgress(
+    func recordDailyProgress(
         action: GrowthActionType,
         on date: Date = Date()
     ) -> PlantRun? {
@@ -183,7 +183,7 @@ public final class GardenStore: ObservableObject {
         persist()
     }
 
-    public func enableNurtureModeForActiveRun() {
+    func enableNurtureModeForActiveRun() {
         guard var run = state.activeRun else { return }
         run.nurtureModeEnabled = true
         state.activeRun = run
@@ -193,12 +193,12 @@ public final class GardenStore: ObservableObject {
         persist()
     }
 
-    public func updateProfile(_ update: (inout GardenProfile) -> Void) {
+    func updateProfile(_ update: (inout GardenProfile) -> Void) {
         update(&state.profile)
         persist()
     }
 
-    public func resetRainDayIfNeeded(on date: Date = Date()) {
+    func resetRainDayIfNeeded(on date: Date = Date()) {
         let weekOfYear = calendar.component(.weekOfYear, from: date)
         if state.flags.lastRainWeekOfYear != weekOfYear {
             state.flags.rainDaysRemainingThisWeek = 1
@@ -207,7 +207,7 @@ public final class GardenStore: ObservableObject {
         }
     }
 
-    public func useRainDayIfAvailable(on date: Date = Date()) -> Bool {
+    func useRainDayIfAvailable(on date: Date = Date()) -> Bool {
         resetRainDayIfNeeded(on: date)
         guard state.flags.rainDaysRemainingThisWeek > 0 else { return false }
         state.flags.rainDaysRemainingThisWeek -= 1
@@ -215,7 +215,7 @@ public final class GardenStore: ObservableObject {
         return true
     }
 
-    public func refreshWeeklyBlossomIfNeeded(for run: PlantRun, on date: Date = Date()) -> PlantRun {
+    func refreshWeeklyBlossomIfNeeded(for run: PlantRun, on date: Date = Date()) -> PlantRun {
         var mutableRun = run
         let entriesThisWeek = run.completedEntries.filter { entry in
             calendar.isDate(entry.date, equalTo: date, toGranularity: .weekOfYear)
@@ -224,7 +224,7 @@ public final class GardenStore: ObservableObject {
         return mutableRun
     }
 
-    public func startNewSeed(with plant: PlantChoice) {
+    func startNewSeed(with plant: PlantChoice) {
         startRun(with: plant)
     }
 
@@ -237,12 +237,12 @@ public final class GardenStore: ObservableObject {
 
 // MARK: - Plant Library
 
-public protocol GrowWithMeProgressHandling {
+protocol GrowWithMeProgressHandling {
     func growWithMeDidComplete(action: GrowthActionType, at date: Date)
 }
 
 extension GardenStore: GrowWithMeProgressHandling {
-    public func growWithMeDidComplete(action: GrowthActionType, at date: Date) {
+    func growWithMeDidComplete(action: GrowthActionType, at date: Date) {
         _ = recordDailyProgress(action: action, on: date)
     }
 }

--- a/Greyspace/GardenStore.swift
+++ b/Greyspace/GardenStore.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+// MARK: - GardenStorage Protocol
+
+protocol GardenStorage {
+    func loadState() -> GardenState
+    func save(state: GardenState)
+}
+
+// MARK: - SwiftData Storage
+
+#if canImport(SwiftData)
+import SwiftData
+
+@available(iOS 17, *)
+final class GardenStoreSwiftData: GardenStorage {
+    private let container: ModelContainer
+
+    @Model
+    final class GardenStateModel {
+        @Attribute(.unique) var key: String
+        var data: Data
+
+        init(key: String, data: Data) {
+            self.key = key
+            self.data = data
+        }
+    }
+
+    init(container: ModelContainer = {
+        let schema = Schema([GardenStateModel.self])
+        return try! ModelContainer(for: schema)
+    }()) {
+        self.container = container
+    }
+
+    func loadState() -> GardenState {
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<GardenStateModel>(predicate: #Predicate { $0.key == "state" })
+        if let model = try? context.fetch(descriptor).first,
+           let state = try? JSONDecoder().decode(GardenState.self, from: model.data) {
+            return state
+        }
+        return GardenState()
+    }
+
+    func save(state: GardenState) {
+        let context = ModelContext(container)
+        let descriptor = FetchDescriptor<GardenStateModel>(predicate: #Predicate { $0.key == "state" })
+        let data = (try? JSONEncoder().encode(state)) ?? Data()
+        if let model = try? context.fetch(descriptor).first {
+            model.data = data
+            try? context.save()
+        } else {
+            let model = GardenStateModel(key: "state", data: data)
+            context.insert(model)
+            try? context.save()
+        }
+    }
+}
+#endif
+
+// MARK: - UserDefaults Storage
+
+final class GardenStoreUserDefaults: GardenStorage {
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func loadState() -> GardenState {
+        guard let data = defaults.data(forKey: Keys.state) else {
+            return GardenState()
+        }
+        return (try? JSONDecoder().decode(GardenState.self, from: data)) ?? GardenState()
+    }
+
+    func save(state: GardenState) {
+        guard let data = try? JSONEncoder().encode(state) else { return }
+        defaults.set(data, forKey: Keys.state)
+    }
+
+    private enum Keys {
+        static let state = "garden.state"
+    }
+}
+
+// MARK: - GardenStore
+
+@MainActor
+public final class GardenStore: ObservableObject {
+    @Published public private(set) var state: GardenState
+
+    private let storage: GardenStorage
+    private let calendar: Calendar
+
+    public init(
+        storage: GardenStorage,
+        initialState: GardenState? = nil,
+        calendar: Calendar = .current
+    ) {
+        self.storage = storage
+        self.calendar = calendar
+        self.state = initialState ?? storage.loadState()
+    }
+
+    public static func makeDefault() -> GardenStore {
+        #if canImport(SwiftData)
+        if #available(iOS 17, *) {
+            return GardenStore(storage: GardenStoreSwiftData())
+        }
+        #endif
+        return GardenStore(storage: GardenStoreUserDefaults())
+    }
+
+    // MARK: - Onboarding
+
+    public func markOnboardingCompleted() {
+        state.hasCompletedOnboarding = true
+        persist()
+    }
+
+    public func resetOnboarding() {
+        state.hasCompletedOnboarding = false
+        persist()
+    }
+
+    // MARK: - Plant Lifecycle
+
+    public func startRun(with plant: PlantChoice) {
+        state.activeRun = PlantRun(plant: plant, startDate: Date())
+        persist()
+    }
+
+    public func abandonRun() {
+        state.activeRun = nil
+        persist()
+    }
+
+    @discardableResult
+    public func recordDailyProgress(
+        action: GrowthActionType,
+        on date: Date = Date()
+    ) -> PlantRun? {
+        guard var run = state.activeRun else {
+            return nil
+        }
+        if run.isComplete {
+            if run.nurtureModeEnabled {
+                let entry = PlantRun.DailyEntry(dayIndex: PlantStage.mature.rawValue, date: date)
+                run.completedEntries.append(entry)
+                run = refreshWeeklyBlossomIfNeeded(for: run, on: date)
+                state.activeRun = run
+                if let index = state.completedRuns.firstIndex(where: { $0.id == run.id }) {
+                    state.completedRuns[index] = run
+                }
+                persist()
+            }
+            return run
+        }
+        guard !run.hasCompletedEntry(on: date, calendar: calendar) else {
+            return run
+        }
+
+        let nextIndex = run.nextDayIndex()
+        run.completedEntries.append(.init(dayIndex: nextIndex, date: date))
+        state.activeRun = run
+        persist()
+
+        if run.isComplete {
+            completeActiveRun()
+        }
+
+        return state.activeRun
+    }
+
+    private func completeActiveRun() {
+        guard var run = state.activeRun else { return }
+        run = refreshWeeklyBlossomIfNeeded(for: run)
+        state.completedRuns.append(run)
+        state.activeRun = run
+        persist()
+    }
+
+    public func enableNurtureModeForActiveRun() {
+        guard var run = state.activeRun else { return }
+        run.nurtureModeEnabled = true
+        state.activeRun = run
+        if let index = state.completedRuns.firstIndex(where: { $0.id == run.id }) {
+            state.completedRuns[index] = run
+        }
+        persist()
+    }
+
+    public func updateProfile(_ update: (inout GardenProfile) -> Void) {
+        update(&state.profile)
+        persist()
+    }
+
+    public func resetRainDayIfNeeded(on date: Date = Date()) {
+        let weekOfYear = calendar.component(.weekOfYear, from: date)
+        if state.flags.lastRainWeekOfYear != weekOfYear {
+            state.flags.rainDaysRemainingThisWeek = 1
+            state.flags.lastRainWeekOfYear = weekOfYear
+            persist()
+        }
+    }
+
+    public func useRainDayIfAvailable(on date: Date = Date()) -> Bool {
+        resetRainDayIfNeeded(on: date)
+        guard state.flags.rainDaysRemainingThisWeek > 0 else { return false }
+        state.flags.rainDaysRemainingThisWeek -= 1
+        persist()
+        return true
+    }
+
+    public func refreshWeeklyBlossomIfNeeded(for run: PlantRun, on date: Date = Date()) -> PlantRun {
+        var mutableRun = run
+        let entriesThisWeek = run.completedEntries.filter { entry in
+            calendar.isDate(entry.date, equalTo: date, toGranularity: .weekOfYear)
+        }
+        mutableRun.weeklyBlossomEarned = entriesThisWeek.count >= 4
+        return mutableRun
+    }
+
+    public func startNewSeed(with plant: PlantChoice) {
+        startRun(with: plant)
+    }
+
+    // MARK: - Persistence
+
+    private func persist() {
+        storage.save(state: state)
+    }
+}
+
+// MARK: - Plant Library
+
+public protocol GrowWithMeProgressHandling {
+    func growWithMeDidComplete(action: GrowthActionType, at date: Date)
+}
+
+extension GardenStore: GrowWithMeProgressHandling {
+    public func growWithMeDidComplete(action: GrowthActionType, at date: Date) {
+        _ = recordDailyProgress(action: action, on: date)
+    }
+}
+

--- a/Greyspace/GardenStore.swift
+++ b/Greyspace/GardenStore.swift
@@ -70,10 +70,50 @@ final class GardenStoreUserDefaults: GardenStorage {
     }
 
     func loadState() -> GardenState {
-        guard let data = defaults.data(forKey: Keys.state) else {
-            return GardenState()
+        let decoder = JSONDecoder()
+        if let data = defaults.data(forKey: Keys.state),
+           let state = try? decoder.decode(GardenState.self, from: data) {
+            return state
         }
-        return (try? JSONDecoder().decode(GardenState.self, from: data)) ?? GardenState()
+
+        var state = GardenState()
+        var didLoadLegacy = false
+
+        if defaults.object(forKey: LegacyKeys.hasCompletedOnboarding) != nil {
+            state.hasCompletedOnboarding = defaults.bool(forKey: LegacyKeys.hasCompletedOnboarding)
+            didLoadLegacy = true
+        }
+
+        if let data = defaults.data(forKey: LegacyKeys.activeRun),
+           let run = try? decoder.decode(PlantRun.self, from: data) {
+            state.activeRun = run
+            didLoadLegacy = true
+        }
+
+        if let data = defaults.data(forKey: LegacyKeys.completedRuns),
+           let runs = try? decoder.decode([PlantRun].self, from: data) {
+            state.completedRuns = runs
+            didLoadLegacy = true
+        }
+
+        if let data = defaults.data(forKey: LegacyKeys.profile),
+           let profile = try? decoder.decode(GardenProfile.self, from: data) {
+            state.profile = profile
+            didLoadLegacy = true
+        }
+
+        if let data = defaults.data(forKey: LegacyKeys.flags),
+           let flags = try? decoder.decode(GardenFlags.self, from: data) {
+            state.flags = flags
+            didLoadLegacy = true
+        }
+
+        if didLoadLegacy {
+            save(state: state)
+            return state
+        }
+
+        return GardenState()
     }
 
     func save(state: GardenState) {
@@ -83,6 +123,14 @@ final class GardenStoreUserDefaults: GardenStorage {
 
     private enum Keys {
         static let state = "garden.state"
+    }
+
+    private enum LegacyKeys {
+        static let hasCompletedOnboarding = "garden.hasCompletedOnboarding"
+        static let activeRun = "garden.activeRun"
+        static let completedRuns = "garden.completedRuns"
+        static let profile = "garden.profile"
+        static let flags = "garden.flags"
     }
 }
 

--- a/Greyspace/GardenView.swift
+++ b/Greyspace/GardenView.swift
@@ -1,0 +1,301 @@
+import SwiftUI
+
+struct GardenView: View {
+    @ObservedObject var store: GardenStore
+    @State private var selection: Tab = .inProgress
+    @State private var showCompletionCard: Bool = false
+
+    enum Tab: String, CaseIterable, Identifiable {
+        case inProgress
+        case myGarden
+        case discover
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .inProgress:
+                return String(localized: "In Progress")
+            case .myGarden:
+                return String(localized: "My Garden")
+            case .discover:
+                return String(localized: "Discover")
+            }
+        }
+    }
+
+    private var activeRun: PlantRun? { store.state.activeRun }
+
+    var body: some View {
+        VStack {
+            Picker("", selection: $selection) {
+                ForEach(Tab.allCases) { tab in
+                    Text(tab.title).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            tabContent
+        }
+        .sheet(isPresented: $showCompletionCard) {
+            CompletionCard(store: store, isPresented: $showCompletionCard)
+                .presentationDetents([.medium, .large])
+        }
+        .onChange(of: store.state.completedRuns) { _ in
+            if let last = store.state.completedRuns.last, calendar.isDateInToday(last.completedEntries.last?.date ?? Date()) {
+                showCompletionCard = true
+            }
+        }
+        .onAppear {
+            store.resetRainDayIfNeeded()
+            if activeRun?.isComplete == true {
+                showCompletionCard = true
+            }
+        }
+        .navigationTitle(String(localized: "Garden"))
+    }
+
+    private var tabContent: some View {
+        Group {
+            switch selection {
+            case .inProgress:
+                InProgressView(store: store)
+            case .myGarden:
+                CompletedGardenView(completedRuns: store.state.completedRuns)
+            case .discover:
+                DiscoverView()
+            }
+        }
+    }
+
+    private var calendar: Calendar { .current }
+}
+
+// MARK: - In Progress
+
+private struct InProgressView: View {
+    @ObservedObject var store: GardenStore
+
+    private var activeRun: PlantRun? { store.state.activeRun }
+
+    var body: some View {
+        VStack(spacing: 24) {
+            if let run = activeRun {
+                ProgressRing(run: run)
+                Button(action: {
+                    // TODO: Link to the existing check-in or Thought Helper action.
+                }) {
+                    Text(String(localized: "Continue today's care"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal)
+                Text(String(localized: "Your plant is resting when you are. Check in when you're ready."))
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+            } else {
+                Text(String(localized: "No active plants. Plant a new seed to begin."))
+                    .font(.body)
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .padding()
+            }
+            Spacer()
+        }
+    }
+}
+
+private struct ProgressRing: View {
+    let run: PlantRun
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .trim(from: 0, to: 1)
+                .stroke(Color.gray.opacity(0.2), style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+
+            Circle()
+                .trim(from: 0, to: CGFloat(run.dayCount) / 7.0)
+                .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 12, lineCap: .round))
+                .rotationEffect(.degrees(-90))
+                .animation(.easeInOut(duration: 0.4), value: run.dayCount)
+
+            VStack(spacing: 8) {
+                Text(run.stage.title)
+                    .font(.title3)
+                    .bold()
+                Text(String(localized: "Day \(run.dayCount) of 7"))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(localized: "\(run.stage.title). Day \(run.dayCount) of seven."))
+        }
+        .frame(width: 200, height: 200)
+        .padding()
+    }
+}
+
+// MARK: - Completed Garden
+
+private struct CompletedGardenView: View {
+    let completedRuns: [PlantRun]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 160), spacing: 16)], spacing: 16) {
+                ForEach(completedRuns) { run in
+                    VStack(alignment: .leading, spacing: 8) {
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.accentColor.opacity(0.15))
+                            .frame(height: 120)
+                            .overlay(
+                                Image(systemName: "leaf")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .padding(32)
+                                    .foregroundColor(.accentColor)
+                            )
+                        Text(run.plant.displayName)
+                            .font(.headline)
+                        if let date = run.completedEntries.last?.date {
+                            Text(date.formatted(date: .abbreviated, time: .omitted))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Text(run.plant.symbolism)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 24)
+                            .fill(Color(.systemBackground))
+                            .shadow(color: Color.black.opacity(0.05), radius: 6, x: 0, y: 2)
+                    )
+                    .accessibilityElement(children: .combine)
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Discover
+
+private struct DiscoverView: View {
+    let lockedPlants: [PlantChoice] = PlantChoice.samplePlants
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                ForEach(lockedPlants) { plant in
+                    HStack(alignment: .center, spacing: 16) {
+                        RoundedRectangle(cornerRadius: 16)
+                            .fill(Color.gray.opacity(0.1))
+                            .frame(width: 60, height: 60)
+                            .overlay(
+                                Image(systemName: "lock")
+                                    .foregroundColor(.secondary)
+                            )
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(plant.displayName)
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                            Text(plant.symbolism)
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                            Text(String(localized: "Complete mindful care to unlock."))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                    }
+                    .padding()
+                    .background(
+                        RoundedRectangle(cornerRadius: 24)
+                            .fill(Color(.systemGroupedBackground))
+                    )
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Completion Card
+
+private struct CompletionCard: View {
+    @ObservedObject var store: GardenStore
+    @Binding var isPresented: Bool
+
+    @State private var confettiOpacity: Double = 0
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 8)
+            RoundedRectangle(cornerRadius: 32)
+                .fill(Color.accentColor.opacity(0.1))
+                .frame(height: 180)
+                .overlay(
+                    VStack(spacing: 16) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 48))
+                            .foregroundColor(.accentColor)
+                            .opacity(confettiOpacity)
+                            .animation(.easeInOut(duration: 1.0), value: confettiOpacity)
+                        Text(String(localized: "Seven days of care"))
+                            .font(.title2)
+                            .bold()
+                        if let plant = store.state.completedRuns.last?.plant {
+                            Text(String(localized: "Your \(plant.displayName) matured."))
+                                .font(.body)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                    }
+                    .padding()
+                )
+            VStack(spacing: 12) {
+                Button {
+                    isPresented = false
+                    if let plant = store.state.completedRuns.last?.plant {
+                        store.startNewSeed(with: plant)
+                    }
+                } label: {
+                    Text(String(localized: "Plant New Seed"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Button {
+                    isPresented = false
+                    store.enableNurtureModeForActiveRun()
+                } label: {
+                    Text(String(localized: "Nurture Mode"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding()
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                confettiOpacity = 1
+            }
+        }
+    }
+}
+
+struct GardenView_Previews: PreviewProvider {
+    static var previews: some View {
+        GardenView(store: GardenStore.makeDefault())
+    }
+}

--- a/Greyspace/GardenView.swift
+++ b/Greyspace/GardenView.swift
@@ -4,6 +4,7 @@ struct GardenView: View {
     @ObservedObject var store: GardenStore
     @State private var selection: Tab = .inProgress
     @State private var showCompletionCard: Bool = false
+    let showSettings: () -> Void
 
     enum Tab: String, CaseIterable, Identifiable {
         case inProgress
@@ -40,6 +41,16 @@ struct GardenView: View {
                 tabContent
             }
             .navigationTitle(String(localized: "Garden"))
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showSettings()
+                    } label: {
+                        Image(systemName: "gearshape.fill")
+                    }
+                    .accessibilityLabel(Text(String(localized: "Settings")))
+                }
+            }
         }
         .sheet(isPresented: $showCompletionCard) {
             CompletionCard(store: store, isPresented: $showCompletionCard)
@@ -298,6 +309,6 @@ private struct CompletionCard: View {
 
 struct GardenView_Previews: PreviewProvider {
     static var previews: some View {
-        GardenView(store: GardenStore.makeDefault())
+        GardenView(store: GardenStore.makeDefault(), showSettings: {})
     }
 }

--- a/Greyspace/GardenView.swift
+++ b/Greyspace/GardenView.swift
@@ -27,16 +27,19 @@ struct GardenView: View {
     private var activeRun: PlantRun? { store.state.activeRun }
 
     var body: some View {
-        VStack {
-            Picker("", selection: $selection) {
-                ForEach(Tab.allCases) { tab in
-                    Text(tab.title).tag(tab)
+        NavigationStack {
+            VStack {
+                Picker("", selection: $selection) {
+                    ForEach(Tab.allCases) { tab in
+                        Text(tab.title).tag(tab)
+                    }
                 }
-            }
-            .pickerStyle(.segmented)
-            .padding()
+                .pickerStyle(.segmented)
+                .padding()
 
-            tabContent
+                tabContent
+            }
+            .navigationTitle(String(localized: "Garden"))
         }
         .sheet(isPresented: $showCompletionCard) {
             CompletionCard(store: store, isPresented: $showCompletionCard)
@@ -53,7 +56,6 @@ struct GardenView: View {
                 showCompletionCard = true
             }
         }
-        .navigationTitle(String(localized: "Garden"))
     }
 
     private var tabContent: some View {

--- a/Greyspace/GrowthModels.swift
+++ b/Greyspace/GrowthModels.swift
@@ -61,7 +61,7 @@ public enum PlantStage: Int, CaseIterable, Codable, Identifiable {
 
 // MARK: - PlantChoice
 
-public struct PlantChoice: Identifiable, Codable, Equatable {
+public struct PlantChoice: Identifiable, Codable, Equatable, Hashable {
     public let id: String
     public let displayName: String
     public let symbolism: String

--- a/Greyspace/GrowthModels.swift
+++ b/Greyspace/GrowthModels.swift
@@ -1,0 +1,325 @@
+import Foundation
+import SwiftUI
+
+// MARK: - PlantRegion
+
+public enum PlantRegion: String, CaseIterable, Codable, Identifiable {
+    case homeCountry
+    case currentRegion
+    case surprise
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .homeCountry:
+            return String(localized: "Home Country")
+        case .currentRegion:
+            return String(localized: "Where I Am Now")
+        case .surprise:
+            return String(localized: "Surprise Me")
+        }
+    }
+}
+
+// MARK: - PlantStage
+
+public enum PlantStage: Int, CaseIterable, Codable, Identifiable {
+    case seed = 1
+    case sprout
+    case leaf
+    case bud
+    case earlyBloom
+    case fullBloom
+    case mature
+
+    public var id: Int { rawValue }
+
+    public var title: String {
+        switch self {
+        case .seed:
+            return String(localized: "Seed")
+        case .sprout:
+            return String(localized: "Sprout")
+        case .leaf:
+            return String(localized: "Leaf")
+        case .bud:
+            return String(localized: "Bud")
+        case .earlyBloom:
+            return String(localized: "Early Bloom")
+        case .fullBloom:
+            return String(localized: "Full Bloom")
+        case .mature:
+            return String(localized: "Mature")
+        }
+    }
+
+    public var accessibilityDescription: String {
+        String(localized: "Stage \(rawValue): \(title)")
+    }
+}
+
+// MARK: - PlantChoice
+
+public struct PlantChoice: Identifiable, Codable, Equatable {
+    public let id: String
+    public let displayName: String
+    public let symbolism: String
+    public let regionTag: String
+    public let region: PlantRegion
+    let assetNameOverride: String?
+
+    public var assetName: String {
+        assetNameOverride ?? "plant_\(id)"
+    }
+
+    public init(
+        id: String,
+        displayName: String,
+        regionTag: String,
+        symbolism: String,
+        assetName: String? = nil
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.regionTag = regionTag
+        self.symbolism = symbolism
+        self.region = PlantChoice.mapRegion(from: regionTag)
+        self.assetNameOverride = assetName
+    }
+
+    private static func mapRegion(from tag: String) -> PlantRegion {
+        switch tag.lowercased() {
+        case "homecountry":
+            return .homeCountry
+        case "currentregion":
+            return .currentRegion
+        default:
+            return .surprise
+        }
+    }
+}
+
+extension PlantChoice {
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case displayName
+        case symbolism
+        case regionTag
+        case region
+        case assetNameOverride
+        case assetName
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        if let decodedID = try? container.decode(String.self, forKey: .id) {
+            id = decodedID
+        } else if let legacyID = try? container.decode(UUID.self, forKey: .id) {
+            id = legacyID.uuidString
+        } else {
+            id = UUID().uuidString
+        }
+
+        displayName = (try? container.decode(String.self, forKey: .displayName)) ?? ""
+        symbolism = (try? container.decode(String.self, forKey: .symbolism)) ?? ""
+
+        if let decodedTag = try? container.decode(String.self, forKey: .regionTag) {
+            regionTag = decodedTag
+            region = PlantChoice.mapRegion(from: decodedTag)
+        } else if let legacyRegion = try? container.decode(PlantRegion.self, forKey: .region) {
+            region = legacyRegion
+            switch legacyRegion {
+            case .homeCountry:
+                regionTag = "HomeCountry"
+            case .currentRegion:
+                regionTag = "CurrentRegion"
+            case .surprise:
+                regionTag = "Surprise"
+            }
+        } else {
+            regionTag = "Surprise"
+            region = .surprise
+        }
+
+        if let override = try? container.decode(String.self, forKey: .assetNameOverride) {
+            assetNameOverride = override
+        } else if let legacyAssetName = try? container.decode(String.self, forKey: .assetName) {
+            assetNameOverride = legacyAssetName
+        } else {
+            assetNameOverride = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(displayName, forKey: .displayName)
+        try container.encode(symbolism, forKey: .symbolism)
+        try container.encode(regionTag, forKey: .regionTag)
+        try container.encode(region.rawValue, forKey: .region)
+        try container.encodeIfPresent(assetNameOverride, forKey: .assetNameOverride)
+    }
+}
+
+// MARK: - Plant Catalog
+
+public enum PlantCatalog {
+    public static let byRegion: [String: [PlantChoice]] = [
+        "South Asia": [
+            .init(id: "lotus", displayName: "Lotus", regionTag: "HomeCountry", symbolism: "renewal"),
+            .init(id: "banyan", displayName: "Banyan", regionTag: "HomeCountry", symbolism: "resilience")
+        ],
+        "Middle East": [
+            .init(id: "jasmine", displayName: "Jasmine", regionTag: "HomeCountry", symbolism: "peace"),
+            .init(id: "olive", displayName: "Olive", regionTag: "HomeCountry", symbolism: "endurance")
+        ],
+        "East Asia": [
+            .init(id: "bamboo", displayName: "Bamboo", regionTag: "HomeCountry", symbolism: "balance"),
+            .init(id: "plum", displayName: "Plum Blossom", regionTag: "HomeCountry", symbolism: "endurance")
+        ],
+        "Canada": [
+            .init(id: "maple", displayName: "Maple", regionTag: "CurrentRegion", symbolism: "steadfastness"),
+            .init(id: "prairie-rose", displayName: "Prairie Rose", regionTag: "CurrentRegion", symbolism: "hope")
+        ],
+        "Universal": [
+            .init(id: "lavender", displayName: "Lavender", regionTag: "Universal", symbolism: "calm"),
+            .init(id: "cactus", displayName: "Cactus", regionTag: "Universal", symbolism: "resilience"),
+            .init(id: "fern", displayName: "Fern", regionTag: "Universal", symbolism: "renewal"),
+            .init(id: "sunflower", displayName: "Sunflower", regionTag: "optimism", symbolism: "optimism")
+        ]
+    ]
+
+    public static var allPlants: [PlantChoice] {
+        byRegion
+            .sorted { $0.key < $1.key }
+            .flatMap { $0.value }
+    }
+}
+
+extension PlantChoice {
+    public static var samplePlants: [PlantChoice] {
+        PlantCatalog.allPlants
+    }
+}
+
+// MARK: - PlantRun
+
+public struct PlantRun: Identifiable, Codable, Equatable {
+    public struct DailyEntry: Codable, Hashable {
+        public let dayIndex: Int
+        public let date: Date
+
+        public init(dayIndex: Int, date: Date) {
+            self.dayIndex = dayIndex
+            self.date = date
+        }
+    }
+
+    public let id: UUID
+    public let plant: PlantChoice
+    public var startDate: Date
+    public var completedEntries: [DailyEntry]
+    public var nurtureModeEnabled: Bool
+    public var weeklyBlossomEarned: Bool
+
+    public init(
+        id: UUID = UUID(),
+        plant: PlantChoice,
+        startDate: Date = Date(),
+        completedEntries: [DailyEntry] = [],
+        nurtureModeEnabled: Bool = false,
+        weeklyBlossomEarned: Bool = false
+    ) {
+        self.id = id
+        self.plant = plant
+        self.startDate = startDate
+        self.completedEntries = completedEntries
+        self.nurtureModeEnabled = nurtureModeEnabled
+        self.weeklyBlossomEarned = weeklyBlossomEarned
+    }
+
+    public var dayCount: Int {
+        min(completedEntries.count, PlantStage.allCases.count)
+    }
+
+    public var stage: PlantStage {
+        PlantStage(rawValue: max(1, min(dayCount, PlantStage.allCases.count))) ?? .seed
+    }
+
+    public var isComplete: Bool {
+        dayCount >= PlantStage.allCases.count
+    }
+
+    public func hasCompletedEntry(on date: Date, calendar: Calendar = .current) -> Bool {
+        completedEntries.contains { entry in
+            calendar.isDate(entry.date, inSameDayAs: date)
+        }
+    }
+
+    public func nextDayIndex() -> Int {
+        min(completedEntries.count + 1, PlantStage.allCases.count)
+    }
+}
+
+// MARK: - GardenProfile
+
+public struct GardenProfile: Codable, Equatable {
+    public var hidePlantOnHome: Bool
+    public var compassionMode: Bool
+    public var preferThoughtHelperForGrowth: Bool
+
+    public init(
+        hidePlantOnHome: Bool = false,
+        compassionMode: Bool = false,
+        preferThoughtHelperForGrowth: Bool = false
+    ) {
+        self.hidePlantOnHome = hidePlantOnHome
+        self.compassionMode = compassionMode
+        self.preferThoughtHelperForGrowth = preferThoughtHelperForGrowth
+    }
+}
+
+// MARK: - GardenFlags
+
+public struct GardenFlags: Codable, Equatable {
+    public var rainDaysRemainingThisWeek: Int
+    public var lastRainWeekOfYear: Int
+
+    public init(rainDaysRemainingThisWeek: Int = 1, lastRainWeekOfYear: Int = -1) {
+        self.rainDaysRemainingThisWeek = rainDaysRemainingThisWeek
+        self.lastRainWeekOfYear = lastRainWeekOfYear
+    }
+}
+
+// MARK: - GardenState
+
+public struct GardenState: Codable, Equatable {
+    public var hasCompletedOnboarding: Bool
+    public var activeRun: PlantRun?
+    public var completedRuns: [PlantRun]
+    public var profile: GardenProfile
+    public var flags: GardenFlags
+
+    public init(
+        hasCompletedOnboarding: Bool = false,
+        activeRun: PlantRun? = nil,
+        completedRuns: [PlantRun] = [],
+        profile: GardenProfile = GardenProfile(),
+        flags: GardenFlags = GardenFlags()
+    ) {
+        self.hasCompletedOnboarding = hasCompletedOnboarding
+        self.activeRun = activeRun
+        self.completedRuns = completedRuns
+        self.profile = profile
+        self.flags = flags
+    }
+}
+
+// MARK: - GrowthActionType
+
+public enum GrowthActionType: String, Codable {
+    case checkIn
+    case thoughtHelper
+}

--- a/Greyspace/GrowthOnboardingFlow.swift
+++ b/Greyspace/GrowthOnboardingFlow.swift
@@ -1,0 +1,267 @@
+import SwiftUI
+
+struct GrowthOnboardingFlow: View {
+    enum Step: Hashable {
+        case welcome
+        case concept
+        case choosePlant
+        case confirm(PlantChoice)
+    }
+
+    @ObservedObject var store: GardenStore
+    let startFirstCheckIn: () -> Void
+
+    @State private var path: [Step] = []
+    @State private var selectedRegion: PlantRegion = .homeCountry
+    @State private var selectedPlant: PlantChoice?
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            WelcomeView(onContinue: { path.append(.concept) })
+                .navigationDestination(for: Step.self) { step in
+                    switch step {
+                    case .welcome:
+                        WelcomeView(onContinue: { path.append(.concept) })
+                    case .concept:
+                        ConceptView(onContinue: { path.append(.choosePlant) })
+                    case .choosePlant:
+                        ChoosePlantView(
+                            selectedRegion: $selectedRegion,
+                            selectedPlant: $selectedPlant,
+                            onContinue: {
+                                if let plant = selectedPlant {
+                                    path.append(.confirm(plant))
+                                }
+                            }
+                        )
+                    case .confirm(let plant):
+                        ConfirmPlantView(
+                            plant: plant,
+                            onStart: {
+                                store.startRun(with: plant)
+                                store.markOnboardingCompleted()
+                                startFirstCheckIn() // TODO: Hook into existing Start First Check-In flow.
+                            }
+                        )
+                    }
+                }
+        }
+        .onAppear {
+            if path.isEmpty {
+                path = [.welcome]
+            }
+        }
+    }
+}
+
+// MARK: - Welcome
+
+struct WelcomeView: View {
+    let onContinue: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            Text(String(localized: "Grow With Me"))
+                .font(.largeTitle)
+                .fontWeight(.semibold)
+                .multilineTextAlignment(.center)
+            Text(String(localized: "A gentle space to watch your reflections bloom."))
+                .font(.title3)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.secondary)
+            Spacer()
+            Button(action: onContinue) {
+                Text(String(localized: "Continue"))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(.horizontal)
+            .accessibilityHint(String(localized: "Move to the next page"))
+            Spacer(minLength: 32)
+        }
+        .padding()
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+// MARK: - Concept
+
+struct ConceptView: View {
+    let onContinue: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 32) {
+                Spacer(minLength: 32)
+                ZStack {
+                    RoundedRectangle(cornerRadius: 24)
+                        .fill(Color.accentColor.opacity(0.15))
+                        .frame(height: 220)
+                    VStack(spacing: 16) {
+                        // TODO: Replace with seed-to-sprout animation when assets are ready.
+                        Image(systemName: "leaf.fill")
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 72, height: 72)
+                            .foregroundStyle(.green)
+                        Text(String(localized: "Every reflection helps your plant grow."))
+                            .font(.title3)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+                Text(String(localized: "Each day you check in or use Thought Helper, your plant takes another step from seed to bloom. Missed days simply become rest days."))
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal)
+                Button(action: onContinue) {
+                    Text(String(localized: "Choose a plant"))
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .padding(.horizontal)
+                .accessibilityLabel(String(localized: "Choose a plant to grow"))
+                Spacer(minLength: 32)
+            }
+            .padding(.vertical)
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+// MARK: - Choose Plant
+
+struct ChoosePlantView: View {
+    @Binding var selectedRegion: PlantRegion
+    @Binding var selectedPlant: PlantChoice?
+    let onContinue: () -> Void
+
+    private var plants: [PlantChoice] {
+        if selectedRegion == .surprise {
+            return PlantChoice.samplePlants
+        }
+        return PlantChoice.samplePlants.filter { $0.region == selectedRegion }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker(String(localized: "Plant source"), selection: $selectedRegion) {
+                ForEach(PlantRegion.allCases) { region in
+                    Text(region.displayName).tag(region)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            ScrollView {
+                LazyVGrid(columns: [GridItem(.adaptive(minimum: 140), spacing: 16)], spacing: 16) {
+                    ForEach(plants) { plant in
+                        PlantChoiceCard(plant: plant, isSelected: plant == selectedPlant)
+                            .onTapGesture {
+                                if selectedRegion == .surprise {
+                                    selectedPlant = PlantChoice.samplePlants.randomElement()
+                                } else {
+                                    selectedPlant = plant
+                                }
+                            }
+                    }
+                }
+                .padding()
+            }
+
+            Button(action: {
+                if selectedPlant == nil, selectedRegion == .surprise {
+                    selectedPlant = PlantChoice.samplePlants.randomElement()
+                }
+                if selectedPlant != nil {
+                    onContinue()
+                }
+            }) {
+                Text(String(localized: "Continue"))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+            .disabled(selectedPlant == nil && selectedRegion != .surprise)
+            .accessibilityLabel(String(localized: "Continue to confirm plant"))
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle(String(localized: "Choose Your Plant"))
+    }
+}
+
+// MARK: - PlantChoiceCard
+
+struct PlantChoiceCard: View {
+    let plant: PlantChoice
+    let isSelected: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 20)
+                    .fill(isSelected ? Color.accentColor.opacity(0.2) : Color(.secondarySystemBackground))
+                // TODO: Replace placeholder with illustration asset referenced by plant.assetName.
+                Image(systemName: "leaf")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: 72)
+                    .foregroundColor(.accentColor)
+            }
+            Text(plant.displayName)
+                .font(.headline)
+            Text(plant.symbolism)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 24)
+                .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+                .background(RoundedRectangle(cornerRadius: 24).fill(Color(.systemBackground)))
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+// MARK: - Confirm
+
+struct ConfirmPlantView: View {
+    let plant: PlantChoice
+    let onStart: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer(minLength: 16)
+            PlantChoiceCard(plant: plant, isSelected: true)
+            Text(String(localized: "Symbolism"))
+                .font(.title3)
+                .fontWeight(.semibold)
+            Text(plant.symbolism)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
+            Spacer()
+            Button(action: onStart) {
+                Text(String(localized: "Start my first check-in"))
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding()
+            .accessibilityLabel(String(localized: "Start first check-in"))
+            Spacer(minLength: 24)
+        }
+        .navigationTitle(String(localized: "You chose \(plant.displayName)"))
+        .background(Color(.systemGroupedBackground))
+    }
+}
+
+// MARK: - Previews
+
+struct GrowthOnboardingFlow_Previews: PreviewProvider {
+    static var previews: some View {
+        GrowthOnboardingFlow(store: GardenStore.makeDefault(), startFirstCheckIn: {})
+    }
+}

--- a/Greyspace/HistoryView.swift
+++ b/Greyspace/HistoryView.swift
@@ -22,6 +22,7 @@ struct HistoryView: View {
     @State private var kind: Kind = .entries
     @State private var query: String = ""
     @State private var sortNewestFirst: Bool = true
+    let showSettings: () -> Void
 
     var body: some View {
         NavigationStack {
@@ -47,6 +48,16 @@ struct HistoryView: View {
                 }
             }
             .navigationTitle("History")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showSettings()
+                    } label: {
+                        Image(systemName: "gearshape.fill")
+                    }
+                    .accessibilityLabel(Text(String(localized: "Settings")))
+                }
+            }
         }
     }
 

--- a/Greyspace/HomePlantWidget.swift
+++ b/Greyspace/HomePlantWidget.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+struct HomePlantWidget: View {
+    @ObservedObject var store: GardenStore
+
+    private var run: PlantRun? { store.state.activeRun }
+
+    var body: some View {
+        Group {
+            if let run, !store.state.profile.hidePlantOnHome {
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack(alignment: .top, spacing: 16) {
+                        RoundedRectangle(cornerRadius: 20)
+                            .fill(Color.accentColor.opacity(0.15))
+                            .frame(width: 80, height: 80)
+                            .overlay(
+                                Image(systemName: "leaf.fill")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .padding(16)
+                                    .foregroundStyle(Color.accentColor)
+                            )
+                            .accessibilityHidden(true)
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text(run.plant.displayName)
+                                .font(.headline)
+                            Text(run.stage.title)
+                                .font(.title3)
+                                .bold()
+                            Text(String(localized: "Day \(run.dayCount) of 7"))
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                    }
+
+                    Text(copy(for: run))
+                        .font(.body)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 28)
+                        .fill(Color(.systemBackground))
+                        .shadow(color: Color.black.opacity(0.08), radius: 10, x: 0, y: 6)
+                )
+                .accessibilityElement(children: .ignore)
+                .accessibilityLabel(
+                    Text(String(localized: "Your \(run.plant.displayName) is at \(run.stage.title) stage. Day \(run.dayCount) of seven."))
+                )
+            } else {
+                EmptyView()
+            }
+        }
+        .onAppear {
+            store.resetRainDayIfNeeded()
+        }
+    }
+
+    private func copy(for run: PlantRun) -> String {
+        if run.isComplete {
+            return String(localized: "Seven days of care. Your \(run.plant.displayName) matured.")
+        }
+        if run.dayCount == 0 {
+            return String(localized: "Welcome to your new plant. Each reflection will help it grow.")
+        }
+        return String(localized: "You watered your \(run.plant.displayName) today. Little steps, real growth.")
+    }
+}
+
+struct HomePlantWidget_Previews: PreviewProvider {
+    static var previews: some View {
+        let store = GardenStore.makeDefault()
+        store.startRun(with: PlantChoice.samplePlants[0])
+        return HomePlantWidget(store: store)
+            .padding()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Greyspace/InsightsView.swift
+++ b/Greyspace/InsightsView.swift
@@ -14,6 +14,7 @@ struct InsightsView: View {
     @Environment(\.calendar) private var calendar
     @Query(sort: \JournalEntry.date, order: .reverse, animation: .default)
     private var entries: [JournalEntry]
+    let showSettings: () -> Void
 
     var body: some View {
         NavigationStack {
@@ -128,6 +129,16 @@ struct InsightsView: View {
             }
             .navigationTitle("Insights")
             .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showSettings()
+                    } label: {
+                        Image(systemName: "gearshape.fill")
+                    }
+                    .accessibilityLabel(Text(String(localized: "Settings")))
+                }
+            }
         }
     }
 }

--- a/Greyspace/RootView.swift
+++ b/Greyspace/RootView.swift
@@ -19,6 +19,7 @@ struct RootView: View {
     @StateObject private var gardenStore = GardenStore.makeDefault()
     @State private var selected: Tab = .today
     @State private var showingSettings = false
+    @State private var isTabBarHidden = false
 
     private let tabs: [TabItem] = TabItem.all
 
@@ -27,7 +28,9 @@ struct RootView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(DS.Color.background.ignoresSafeArea())
             .safeAreaInset(edge: .bottom) {
-                CustomTabBar(selected: $selected, tabs: tabs)
+                if !isTabBarHidden {
+                    CustomTabBar(selected: $selected, tabs: tabs)
+                }
             }
             .sheet(isPresented: $showingSettings) {
                 NavigationStack {
@@ -44,6 +47,7 @@ struct RootView: View {
         case .today:
             TodayView(gardenStore: gardenStore,
                       selectedTab: $selected,
+                      isTabBarHidden: $isTabBarHidden,
                       showSettings: { showingSettings = true })
         case .history:
             HistoryView(showSettings: { showingSettings = true })

--- a/Greyspace/RootView.swift
+++ b/Greyspace/RootView.swift
@@ -12,10 +12,12 @@ struct RootView: View {
     enum Tab: Hashable, CaseIterable {
         case today
         case history
+        case garden
         case insights
         case support
     }
 
+    @StateObject private var gardenStore = GardenStore.makeDefault()
     @State private var selected: Tab = .today
 
     private let tabs: [TabItem] = TabItem.all
@@ -33,13 +35,15 @@ struct RootView: View {
     private func content(for tab: Tab) -> some View {
         switch tab {
         case .today:
-            TodayView(selectedTab: $selected)
+            TodayView(gardenStore: gardenStore, selectedTab: $selected)
         case .history:
             HistoryView()
+        case .garden:
+            GardenView(store: gardenStore)
         case .insights:
             InsightsView()
         case .support:
-            SettingsView()
+            SettingsView(gardenStore: gardenStore)
         }
     }
 }
@@ -55,6 +59,7 @@ private struct TabItem: Identifiable {
     static let all: [TabItem] = [
         TabItem(tab: .today, icon: "sun.max.fill", titleKey: "tab.today", accessibilityKey: "tab.today.accessibility"),
         TabItem(tab: .history, icon: "clock.arrow.circlepath", titleKey: "tab.history", accessibilityKey: "tab.history.accessibility"),
+        TabItem(tab: .garden, icon: "leaf.fill", titleKey: "tab.garden", accessibilityKey: "tab.garden.accessibility"),
         TabItem(tab: .insights, icon: "chart.line.uptrend.xyaxis", titleKey: "tab.insights", accessibilityKey: "tab.insights.accessibility"),
         TabItem(tab: .support, icon: "heart.fill", titleKey: "tab.support", accessibilityKey: "tab.support.accessibility")
     ]

--- a/Greyspace/RootView.swift
+++ b/Greyspace/RootView.swift
@@ -14,11 +14,11 @@ struct RootView: View {
         case history
         case garden
         case insights
-        case support
     }
 
     @StateObject private var gardenStore = GardenStore.makeDefault()
     @State private var selected: Tab = .today
+    @State private var showingSettings = false
 
     private let tabs: [TabItem] = TabItem.all
 
@@ -29,21 +29,29 @@ struct RootView: View {
             .safeAreaInset(edge: .bottom) {
                 CustomTabBar(selected: $selected, tabs: tabs)
             }
+            .sheet(isPresented: $showingSettings) {
+                NavigationStack {
+                    SettingsView(gardenStore: gardenStore)
+                        .navigationTitle(String(localized: "Settings"))
+                        .navigationBarTitleDisplayMode(.inline)
+                }
+            }
     }
 
     @ViewBuilder
     private func content(for tab: Tab) -> some View {
         switch tab {
         case .today:
-            TodayView(gardenStore: gardenStore, selectedTab: $selected)
+            TodayView(gardenStore: gardenStore,
+                      selectedTab: $selected,
+                      showSettings: { showingSettings = true })
         case .history:
-            HistoryView()
+            HistoryView(showSettings: { showingSettings = true })
         case .garden:
-            GardenView(store: gardenStore)
+            GardenView(store: gardenStore,
+                       showSettings: { showingSettings = true })
         case .insights:
-            InsightsView()
-        case .support:
-            SettingsView(gardenStore: gardenStore)
+            InsightsView(showSettings: { showingSettings = true })
         }
     }
 }
@@ -60,8 +68,7 @@ private struct TabItem: Identifiable {
         TabItem(tab: .today, icon: "sun.max.fill", titleKey: "tab.today", accessibilityKey: "tab.today.accessibility"),
         TabItem(tab: .history, icon: "clock.arrow.circlepath", titleKey: "tab.history", accessibilityKey: "tab.history.accessibility"),
         TabItem(tab: .garden, icon: "leaf.fill", titleKey: "tab.garden", accessibilityKey: "tab.garden.accessibility"),
-        TabItem(tab: .insights, icon: "chart.line.uptrend.xyaxis", titleKey: "tab.insights", accessibilityKey: "tab.insights.accessibility"),
-        TabItem(tab: .support, icon: "heart.fill", titleKey: "tab.support", accessibilityKey: "tab.support.accessibility")
+        TabItem(tab: .insights, icon: "chart.line.uptrend.xyaxis", titleKey: "tab.insights", accessibilityKey: "tab.insights.accessibility")
     ]
 }
 
@@ -86,6 +93,7 @@ private struct CustomTabBar: View {
                             Text(item.titleKey)
                                 .font(DS.Typography.caption())
                                 .lineLimit(1)
+                                .minimumScaleFactor(0.8)
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, DS.Spacing.sm)

--- a/Greyspace/SettingsView+Growth.swift
+++ b/Greyspace/SettingsView+Growth.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct GrowthSettingsSection: View {
+    @ObservedObject var store: GardenStore
+
+    var body: some View {
+        Section(header: Text(String(localized: "Grow With Me"))) {
+            Toggle(isOn: Binding(
+                get: { store.state.profile.hidePlantOnHome },
+                set: { newValue in
+                    store.updateProfile { $0.hidePlantOnHome = newValue }
+                }
+            )) {
+                Text(String(localized: "Hide plant on Home"))
+            }
+
+            Toggle(isOn: Binding(
+                get: { store.state.profile.compassionMode },
+                set: { newValue in
+                    store.updateProfile { $0.compassionMode = newValue }
+                }
+            )) {
+                Text(String(localized: "Compassion Mode"))
+            }
+            .accessibilityHint(String(localized: "Removes visible streak visuals."))
+        }
+    }
+}
+
+struct GrowthSettingsSection_Previews: PreviewProvider {
+    static var previews: some View {
+        Form {
+            GrowthSettingsSection(store: GardenStore.makeDefault())
+        }
+    }
+}

--- a/Greyspace/SupportView.swift
+++ b/Greyspace/SupportView.swift
@@ -12,6 +12,7 @@ import LocalAuthentication
 import SwiftData
 
 struct SettingsView: View {
+    @ObservedObject var gardenStore: GardenStore
     @Environment(\.openURL) private var openURL
     @Environment(\.modelContext) private var context
     @Query(sort: \JournalEntry.date, order: .reverse) private var entries: [JournalEntry]
@@ -64,6 +65,8 @@ struct SettingsView: View {
                             .foregroundStyle(DS.Color.muted)
                     }
                 }
+
+                GrowthSettingsSection(store: gardenStore)
 
                 // MARK: – Privacy & Security
                 Section(header: Text("Privacy & Security"),

--- a/Greyspace/TodayView.swift
+++ b/Greyspace/TodayView.swift
@@ -11,6 +11,7 @@ import SwiftData
 import PhotosUI
 
 struct TodayView: View {
+    @ObservedObject var gardenStore: GardenStore
     @Environment(\.modelContext) private var context
     @Binding var selectedTab: RootView.Tab
 
@@ -42,6 +43,7 @@ struct TodayView: View {
     var entries: [JournalEntry]
 
     @State private var showCBT = false
+    @State private var showGrowthOnboarding = false
 
     var body: some View {
         NavigationStack {
@@ -61,6 +63,15 @@ struct TodayView: View {
                 NotificationService.scheduleDaily(reminder: .evening, id: "reminder.evening")
             }
         }
+        .onAppear { evaluateGrowthOnboarding() }
+        .onChange(of: gardenStore.state.hasCompletedOnboarding) { _ in
+            evaluateGrowthOnboarding()
+        }
+        .fullScreenCover(isPresented: $showGrowthOnboarding) {
+            GrowthOnboardingFlow(store: gardenStore) {
+                dismissGrowthOnboardingAndStartCheckIn()
+            }
+        }
     }
 
     // MARK: - HOME
@@ -69,6 +80,11 @@ struct TodayView: View {
         let language = AppLanguage.resolved(for: appLanguageCode)
         return ScrollView {
             VStack(spacing: DS.Spacing.xl) {
+                if gardenStore.state.activeRun != nil, !gardenStore.state.profile.hidePlantOnHome {
+                    HomePlantWidget(store: gardenStore)
+                        .padding(.horizontal, DS.Spacing.lg)
+                }
+
                 SurfaceCard {
                     HStack(spacing: DS.Spacing.lg) {
                         if let _ = UIImage(named: "GreyspaceLogo") {
@@ -147,13 +163,7 @@ struct TodayView: View {
                 // CTA
                 // In TodayView, replace your Start Check-In button with:
                 Button {
-                    if skipCheckInIntro {
-                        // jump straight to wizard
-                        draft = JournalEntry()
-                        withAnimation { mode = .wizard }
-                    } else {
-                        showCheckInIntro = true
-                    }
+                    startCheckInFlow()
                 } label: {
                     Text("Start Check-In")
                         .frame(maxWidth: .infinity)
@@ -162,10 +172,7 @@ struct TodayView: View {
                 .padding(.horizontal, DS.Spacing.lg)
                 .sheet(isPresented: $showCheckInIntro) {
                     CheckInIntroSheet {
-                        // onStart → actually begin the wizard
-                        draft = JournalEntry()
-                        withAnimation { mode = .wizard }
-                        showCheckInIntro = false
+                        beginWizardFlow()
                     }
                 }
 
@@ -222,6 +229,31 @@ struct TodayView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    private func evaluateGrowthOnboarding() {
+        showGrowthOnboarding = !gardenStore.state.hasCompletedOnboarding
+    }
+
+    private func dismissGrowthOnboardingAndStartCheckIn() {
+        showGrowthOnboarding = false
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            startCheckInFlow()
+        }
+    }
+
+    private func startCheckInFlow() {
+        if skipCheckInIntro {
+            beginWizardFlow()
+        } else {
+            showCheckInIntro = true
+        }
+    }
+
+    private func beginWizardFlow() {
+        draft = JournalEntry()
+        withAnimation { mode = .wizard }
+        showCheckInIntro = false
     }
 
     // MARK: - WIZARD
@@ -493,6 +525,8 @@ struct TodayView: View {
         )
         context.insert(entry)
         do { try context.save() } catch { print("Save error: \(error)") }
+
+        gardenStore.growWithMeDidComplete(action: .checkIn, at: .now)
 
         let decision = PromptEngine.decide(mood: mood, anxiety: anxiety)
         if decision.shouldSuggestCBT { showCBT = true }

--- a/Greyspace/TodayView.swift
+++ b/Greyspace/TodayView.swift
@@ -14,6 +14,7 @@ struct TodayView: View {
     @ObservedObject var gardenStore: GardenStore
     @Environment(\.modelContext) private var context
     @Binding var selectedTab: RootView.Tab
+    @Binding var isTabBarHidden: Bool
     let showSettings: () -> Void
 
     // Mode: home card vs. wizard
@@ -74,15 +75,22 @@ struct TodayView: View {
                 NotificationService.scheduleDaily(reminder: .evening, id: "reminder.evening")
             }
         }
-        .onAppear { evaluateGrowthOnboarding() }
+        .onAppear {
+            evaluateGrowthOnboarding()
+            isTabBarHidden = (mode == .wizard)
+        }
         .onChange(of: gardenStore.state.hasCompletedOnboarding) { _ in
             evaluateGrowthOnboarding()
+        }
+        .onChange(of: mode) { newValue in
+            isTabBarHidden = (newValue == .wizard)
         }
         .fullScreenCover(isPresented: $showGrowthOnboarding) {
             GrowthOnboardingFlow(store: gardenStore) {
                 dismissGrowthOnboardingAndStartCheckIn()
             }
         }
+        .onDisappear { isTabBarHidden = false }
     }
 
     // MARK: - HOME
@@ -523,6 +531,7 @@ struct TodayView: View {
 
     private func resetToHome() {
         mode = .home
+        isTabBarHidden = false
         step = 1
         mood = 3
         anxiety = 3

--- a/Greyspace/TodayView.swift
+++ b/Greyspace/TodayView.swift
@@ -14,6 +14,7 @@ struct TodayView: View {
     @ObservedObject var gardenStore: GardenStore
     @Environment(\.modelContext) private var context
     @Binding var selectedTab: RootView.Tab
+    let showSettings: () -> Void
 
     // Mode: home card vs. wizard
     enum Mode { case home, wizard }
@@ -52,6 +53,16 @@ struct TodayView: View {
             }
             .navigationTitle("Today")
             .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showSettings()
+                    } label: {
+                        Image(systemName: "gearshape.fill")
+                    }
+                    .accessibilityLabel(Text(String(localized: "Settings")))
+                }
+            }
             .onChange(of: selectedTab) { newValue in
                 if newValue == .today {
                     withAnimation { resetToHome() }
@@ -268,10 +279,19 @@ struct TodayView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, DS.Spacing.lg)
             }
-            .padding(.bottom, 120)
+            .padding(.bottom, DS.Spacing.xl * 3)
         }
-        .toolbar {
-            ToolbarItemGroup(placement: .bottomBar) {
+        .scrollDismissesKeyboard(.interactively)
+        .ignoresSafeArea(.keyboard, edges: .bottom)
+        .safeAreaInset(edge: .bottom) { wizardControls }
+    }
+
+    private var wizardControls: some View {
+        VStack(spacing: 0) {
+            Divider()
+                .background(DS.Color.surface.opacity(0.4))
+
+            HStack(spacing: DS.Spacing.md) {
                 Button("Back") {
                     if step == 1 { withAnimation { mode = .home } }
                     else { step -= 1 }
@@ -291,9 +311,11 @@ struct TodayView: View {
                 }
                 .buttonStyle(PrimaryButtonStyle())
             }
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, DS.Spacing.lg)
+            .padding(.vertical, DS.Spacing.md)
+            .background(DS.Color.surface.opacity(0.98).ignoresSafeArea(edges: .bottom))
         }
-        .scrollDismissesKeyboard(.interactively)
-        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 
     @ViewBuilder

--- a/Greyspace/en.lproj/Localizable.strings
+++ b/Greyspace/en.lproj/Localizable.strings
@@ -36,10 +36,12 @@
 // Tab bar
 "tab.today" = "Today";
 "tab.history" = "History";
+"tab.garden" = "Garden";
 "tab.insights" = "Insights";
 "tab.support" = "Support";
 "tab.today.accessibility" = "Switch to Today tab";
 "tab.history.accessibility" = "Switch to History tab";
+"tab.garden.accessibility" = "Switch to Garden tab";
 "tab.insights.accessibility" = "Switch to Insights tab";
 "tab.support.accessibility" = "Switch to Support tab";
 

--- a/Greyspace/fil.lproj/Localizable.strings
+++ b/Greyspace/fil.lproj/Localizable.strings
@@ -35,10 +35,12 @@
 // Tab bar
 "tab.today" = "Ngayon";
 "tab.history" = "Kasaysayan";
+"tab.garden" = "Hardin";
 "tab.insights" = "Mga Insight";
 "tab.support" = "Suporta";
 "tab.today.accessibility" = "Lumipat sa tab na Ngayon";
 "tab.history.accessibility" = "Lumipat sa tab na Kasaysayan";
+"tab.garden.accessibility" = "Lumipat sa tab na Hardin";
 "tab.insights.accessibility" = "Lumipat sa tab na Mga Insight";
 "tab.support.accessibility" = "Lumipat sa tab na Suporta";
 

--- a/Greyspace/hi.lproj/Localizable.strings
+++ b/Greyspace/hi.lproj/Localizable.strings
@@ -35,10 +35,12 @@
 // Tab bar
 "tab.today" = "आज";
 "tab.history" = "इतिहास";
+"tab.garden" = "बगीचा";
 "tab.insights" = "अंतर्दृष्टि";
 "tab.support" = "सहायता";
 "tab.today.accessibility" = "आज टैब पर जाएँ";
 "tab.history.accessibility" = "इतिहास टैब पर जाएँ";
+"tab.garden.accessibility" = "बगीचा टैब पर जाएँ";
 "tab.insights.accessibility" = "अंतर्दृष्टि टैब पर जाएँ";
 "tab.support.accessibility" = "सहायता टैब पर जाएँ";
 

--- a/Greyspace/zh-Hans.lproj/Localizable.strings
+++ b/Greyspace/zh-Hans.lproj/Localizable.strings
@@ -35,10 +35,12 @@
 // Tab bar
 "tab.today" = "今日";
 "tab.history" = "历史";
+"tab.garden" = "花园";
 "tab.insights" = "洞察";
 "tab.support" = "支持";
 "tab.today.accessibility" = "切换到“今日”标签";
 "tab.history.accessibility" = "切换到“历史”标签";
+"tab.garden.accessibility" = "切换到“花园”标签";
 "tab.insights.accessibility" = "切换到“洞察”标签";
 "tab.support.accessibility" = "切换到“支持”标签";
 


### PR DESCRIPTION
## Summary
- add a regional PlantCatalog to centralize Grow With Me plant definitions
- update PlantChoice to use stable identifiers, region tags, and backward-compatible coding
- remove the obsolete inline sample plant list in GardenStore so features consume the catalog data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e7082750248324b0c4f2ea1125e5b9